### PR TITLE
Fallback behavior for inadvertent string formatters in log messages

### DIFF
--- a/src/main/java/com/github/tony19/timber/loggly/LogglyTree.java
+++ b/src/main/java/com/github/tony19/timber/loggly/LogglyTree.java
@@ -21,7 +21,7 @@ import timber.log.Timber;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import java.util.MissingFormatArgumentException
+import java.util.MissingFormatArgumentException;
 
 /**
  * A <a href="https://github.com/JakeWharton/timber">Timber</a> tree that posts

--- a/src/main/java/com/github/tony19/timber/loggly/LogglyTree.java
+++ b/src/main/java/com/github/tony19/timber/loggly/LogglyTree.java
@@ -155,9 +155,15 @@ public class LogglyTree extends Timber.HollowTree implements Timber.TaggedTree {
      * @return JSON string
      */
     private String toJson(Level level, String message, Object... args) {
-        return String.format("{\"level\": \"%1$s\", \"message\": \"%2$s\"}",
-                            level,
-                            String.format(message, args).replace("\"", "\\\""));
+        try {
+            return String.format("{\"level\": \"%1$s\", \"message\": \"%2$s\"}",
+                                level,
+                                String.format(message, args).replace("\"", "\\\""));
+        } catch(MissingFormatArgumentException exception) {
+            return String.format("{\"level\": \"%1$s\", \"message\": \"%2$s\"}",
+                                level,
+                                message.replace("\"", "\\\""));
+        }
     }
 
     /**
@@ -180,10 +186,18 @@ public class LogglyTree extends Timber.HollowTree implements Timber.TaggedTree {
      * @return JSON string
      */
     private String toJson(Level level, String message, Throwable t, Object... args) {
-        return String.format("{\"level\": \"%1$s\", \"message\": \"%2$s\", \"exception\": \"%3$s\"}",
-            level,
-            String.format(message, args).replace("\"", "\\\""),
-            formatThrowable(t));
+        try {
+            return String.format("{\"level\": \"%1$s\", \"message\": \"%2$s\", \"exception\": \"%3$s\"}",
+                level,
+                String.format(message, args).replace("\"", "\\\""),
+                formatThrowable(t)); 
+        } catch(MissingFormatArgumentException exception) {
+            return String.format("{\"level\": \"%1$s\", \"message\": \"%2$s\", \"exception\": \"%3$s\"}",
+                                level,
+                                message.replace("\"", "\\\""),
+                                formatThrowable(t));
+        }
+ 
     }
 
     /**

--- a/src/main/java/com/github/tony19/timber/loggly/LogglyTree.java
+++ b/src/main/java/com/github/tony19/timber/loggly/LogglyTree.java
@@ -21,6 +21,8 @@ import timber.log.Timber;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import java.util.MissingFormatArgumentException
+
 /**
  * A <a href="https://github.com/JakeWharton/timber">Timber</a> tree that posts
  * log messages to <a href="http://loggly.com">Loggly</a>


### PR DESCRIPTION
Fixes #8 

If we get a `java.util.MissingFormatArgumentException`, we just throw the message to the logger as-is and forget about trying to format any args into it. It's suboptimal behavior if you actually passed format arguments, but also it doesn't crash the app in the converse case.
