### PR TITLE
Update Dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Download
 #### Gradle
 
 ```
-compile 'com.github.tony19:timber-loggly:1.0.1'
+compile 'com.github.tony19:timber-loggly:1.0.2'
 compile 'com.squareup.retrofit:retrofit:1.9.0'
 ```
 
@@ -47,7 +47,7 @@ compile 'com.squareup.retrofit:retrofit:1.9.0'
 <dependency>
   <groupId>com.github.tony19</groupId>
   <artifactId>timber-loggly</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 </dependency>
 <dependency>
   <groupId>com.squareup.retrofit</groupId>

--- a/timber-loggly/build.gradle
+++ b/timber-loggly/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testCompile 'com.fasterxml.jackson.core:jackson-annotations:2.6.3'
 
     compile 'com.jakewharton.timber:timber:4.1.2'
-    compile ('com.github.tony19:loggly-client:1.0.3') {
+    compile ('com.github.tony19:loggly-client:1.0.4') {
         exclude group:'com.jakewharton.timber', module:'timber'
     }
 }


### PR DESCRIPTION
In this PR, I've updated the `timber-loggly` dependency to the next version to call updated `Loggly-Client` dependency which include HTTPS Loggly URL. Currently, `Loggly-Client` is not updated with the mentioned version and dependent on the `Loggly-Client` library maintainer. 

Note: Please merge this PR only before deploying the new `Loggly-Client` bump version. 

Thanks!